### PR TITLE
Fix response header schema output

### DIFF
--- a/lib/oas_objs/header_obj.rb
+++ b/lib/oas_objs/header_obj.rb
@@ -16,8 +16,7 @@ module OpenApi
       end
 
       def process
-        schema.process
-        processed.merge!(schema: schema)
+        processed.merge!(schema: schema.process)
       end
     end
   end


### PR DESCRIPTION
This PR addresses #48 by ensuring that the processed `SchemaObj` is merged rather than the `SchemaObj` object itself processing `HeaderObj` instances.

This removes occurrences of `_enum`, `_length` etc which violate the OpenAPI 3 spec.