### PR TITLE
change formatter class in Rails 6

### DIFF
--- a/lib/open_api/router.rb
+++ b/lib/open_api/router.rb
@@ -15,7 +15,11 @@ module OpenApi
             all_routes = Rails.application.routes.routes
             require 'action_dispatch/routing/inspector'
             inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
-            inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, nil)
+            if Rails::VERSION::MAJOR < 6
+              inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, nil)
+            else
+              inspector.format(ActionDispatch::Routing::ConsoleFormatter::Sheet.new)
+            end
             # :nocov:
           end
     end


### PR DESCRIPTION
Seems the classes changed in Rails 6.

https://github.com/rails/rails/blob/beb0bc9907a31d0cbd2ca68c79c57a9e375761e8/actionpack/lib/action_dispatch/routing/inspector.rb#L166