### PR TITLE
Ensure global_security not defaulting to null

### DIFF
--- a/lib/open_api.rb
+++ b/lib/open_api.rb
@@ -50,7 +50,7 @@ module OpenApi
   def init_hash(doc_name)
     settings = Config.docs[doc_name]
     doc = { openapi: '3.0.0', **settings.slice(:info, :servers) }.merge!(
-        security: settings[:global_security], tags: [ ], paths: { },
+        security: settings[:global_security] || [], tags: [ ], paths: { },
         components: {
             securitySchemes: settings[:securitySchemes] || { },
             schemas: { }, parameters: { }, requestBodies: { }


### PR DESCRIPTION
Because it's breaking for openapi-client generator and not allow us to have partially or fully public APIs.